### PR TITLE
Add folding at basic template level only.

### DIFF
--- a/ftplugin/soy/folding.vim
+++ b/ftplugin/soy/folding.vim
@@ -1,0 +1,38 @@
+setlocal foldmethod=expr
+setlocal foldexpr=GetSoyFold(v:lnum)
+
+" Main foldexpr function called for every line.
+function! GetSoyFold(lnum)
+  " Don't fold the namespace.
+  if getline(a:lnum) =~? '^{namespace.*$'
+    return '0'
+  endif
+  
+  " Open fold level 1 for comments.
+  if getline(a:lnum) =~? '\v\/\*\*.*$'
+    return '>1'
+  endif
+  
+  " Close fold level 1 for comments.
+  if getline(a:lnum) =~? '\v\s\*\/$'
+    return '<1'
+  endif
+  
+  " Empty lines get the fold level of the lesser neighbor level
+  if getline(a:lnum) =~? '\v^\s*$'
+    return '-1'
+  endif
+
+  " Open fold level 1 for template region.
+  if getline(a:lnum) =~? '^{template.*$'
+    return '>1'
+  endif
+
+  " Close fold level 1 for template region.
+  if getline(a:lnum) =~? '^{/template}$'
+    return '<1'
+  endif
+
+  " for everything else return unknown level
+  return '-1'
+endfunction


### PR DESCRIPTION
I saw a small tutorial on folding and decided to use it in practice for soy folding.

Generally the {namespace} is never folded, just the /*\* comments */ and {template} are folded.
It seams that folding can be done with foldmethod=syntax, but I did it with expr easier.
When someone does it better in the syntax file, we can remove this one.
